### PR TITLE
Fixes DNS resolution Error

### DIFF
--- a/lib/shared/index.js
+++ b/lib/shared/index.js
@@ -33,8 +33,10 @@ const resolver = (family, hostname, callback) => {
     if (!familySupported) {
         return callback(null, []);
     }
-
-    dns['resolve' + family](hostname, (err, addresses) => {
+    
+    dns['lookup'](hostname,{
+    family
+    } (err, addresses) => {
         if (err) {
             switch (err.code) {
                 case dns.NODATA:


### PR DESCRIPTION
Replace the resolve method with  lookup to ensure all dns entry are verified before resolution ends in failure. Additionally ensures OS host entries are also resolved.

NB! Nodemailer is frozen, so no new features please, only bug fixes.
